### PR TITLE
Feature/13 낫투두 생성 뷰

### DIFF
--- a/app/src/main/java/kr/co/nottodo/presentation/MainActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/MainActivity.kt
@@ -9,6 +9,7 @@ import com.google.android.material.shape.ShapeAppearanceModel
 import com.google.android.material.shape.TriangleEdgeTreatment
 import kr.co.nottodo.R
 import kr.co.nottodo.databinding.ActivityMainBinding
+import kr.co.nottodo.presentation.achievement.view.AchievementFragment
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
@@ -32,5 +33,32 @@ class MainActivity : AppCompatActivity() {
         }
         binding.customBottom.background = backgroundDrawable
         binding.customBottom.itemIconTintList = null
+
+        binding.customBottom.setOnItemSelectedListener {
+            when(it.itemId){
+                R.id.menu_home -> {
+
+                    return@setOnItemSelectedListener true
+                }
+                R.id.menu_recommend -> {
+
+                    return@setOnItemSelectedListener true
+                }
+                R.id.menu_result -> {
+                    supportFragmentManager.beginTransaction()
+                        .replace(R.id.fragment_container_view_main, AchievementFragment())
+                        .commit()
+                    return@setOnItemSelectedListener true
+                }
+                R.id.menu_profile -> {
+
+                    return@setOnItemSelectedListener true
+                }
+                else -> {
+
+                    return@setOnItemSelectedListener false
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/view/AdditionActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/view/AdditionActivity.kt
@@ -21,32 +21,31 @@ class AdditionActivity : AppCompatActivity() {
         setContentView(R.layout.activity_addition)
         initBinding()
         initBottomSheet()
+        btnActionPlusOnClickListener()
         binding.btnAdditionAdd.setOnClickListener {
             // 서버 통신을 통해 낫투두 추가하는 기능
         }
         binding.layoutAdditionMoveSituationPage.setOnClickListener {
-            // 상황 추가 창으로 이동
+            // 상황 추가 화면으로 이동
         }
         binding.ivAdditionMoveSituationPage.setOnClickListener {
             viewModel.additionSituationName.value = "출근 시간"
+        } // 추후 상황 추가 화면 구현시 개발
+        binding.layoutAdditionMoveRecommendPage.setOnClickListener {
+            // 추후 행동 추천 화면 구현시 개발
         }
-        btnActionPlusOnClickListener()
+        observeEditText()
         btnDeleteActionOnClickListener()
+        ivDeletePageOnClickListener()
 
+        observeToActivateAddBtn()
     }
 
-    private fun initBinding() {
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_addition)
-        binding.vm = viewModel
-        binding.lifecycleOwner = this
-    }
-
-    private fun initBottomSheet() {
-        binding.layoutAdditionCalendar.setOnClickListener {
-            CalendarBottomSheet().show(supportFragmentManager, CalendarBottomSheet().tag)
+    private fun ivDeletePageOnClickListener() {
+        binding.ivAdditionDeletePage.setOnClickListener {
+            finish()
         }
     }
-
 
     private fun btnDeleteActionOnClickListener() {
         with(binding) {
@@ -93,6 +92,60 @@ class AdditionActivity : AppCompatActivity() {
                 }
             }
 
+        }
+    }
+
+    private fun initBinding() {
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_addition)
+        binding.vm = viewModel
+        binding.lifecycleOwner = this
+    }
+
+    private fun initBottomSheet() {
+        binding.layoutAdditionCalendar.setOnClickListener {
+            CalendarBottomSheet().show(supportFragmentManager, CalendarBottomSheet().tag)
+        }
+    }
+
+    private fun observeEditText() {
+        viewModel.isAdditionMissionNameFilled.observe(this) {
+            if (it) {
+                binding.etAdditionMissionName.setBackgroundResource(R.drawable.rectangle_border_gray2_1)
+            } else {
+                binding.etAdditionMissionName.setBackgroundResource(R.drawable.rectangle_border_gray4_1)
+            }
+        }
+        viewModel.isAdditionGoalNameFilled.observe(this) {
+            if (it) {
+                binding.etAdditionGoalTitle.setBackgroundResource(R.drawable.rectangle_border_gray2_1)
+            } else {
+                binding.etAdditionGoalTitle.setBackgroundResource(R.drawable.rectangle_border_gray4_1)
+            }
+        }
+        viewModel.isAdditionActionNameFilled.observe(this) {
+            if (it) {
+                binding.etAdditionActionName.setBackgroundResource(R.drawable.rectangle_border_gray2_1)
+            } else {
+                binding.etAdditionActionName.setBackgroundResource(R.drawable.rectangle_border_gray4_1)
+            }
+        }
+    }
+
+    private fun observeToActivateAddBtn() {
+        viewModel.isBtnSuitConditions.observe(this) {
+            if (it) {
+                binding.btnAdditionAdd.setBackgroundColor(getColor(R.color.black_2a292d))
+                binding.btnAdditionAdd.isEnabled = true
+            } else {
+                binding.btnAdditionAdd.setBackgroundColor(getColor(R.color.gray_2_8e8e93))
+                binding.btnAdditionAdd.isEnabled = false
+            }
+        }
+    }
+
+    private fun setDropdownMenu() {
+        binding.etAdditionMissionName.setOnClickListener {
+            AdditionDropdownFragment().show(supportFragmentManager, AdditionDropdownFragment().tag)
         }
     }
 

--- a/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/view/AdditionActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/view/AdditionActivity.kt
@@ -1,0 +1,100 @@
+package kr.co.nottodo.presentation.schedule.addition.view
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import kr.co.nottodo.R
+import kr.co.nottodo.databinding.ActivityAdditionBinding
+import kr.co.nottodo.presentation.schedule.addition.viewmodel.AdditionViewModel
+
+class AdditionActivity : AppCompatActivity() {
+    lateinit var binding: ActivityAdditionBinding
+    private val viewModel by lazy {
+        AdditionViewModel()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_addition)
+        initBinding()
+        binding.btnAdditionAdd.setOnClickListener {
+            // 서버 통신을 통해 낫투두 추가하는 기능
+        }
+        binding.layoutAdditionMoveSituationPage.setOnClickListener {
+            // 상황 추가 창으로 이동
+        }
+        binding.ivAdditionMoveSituationPage.setOnClickListener {
+            viewModel.additionSituationName.value = "출근 시간"
+        }
+        btnActionPlusOnClickListener()
+        btnDeleteActionOnClickListener()
+
+    }
+
+    private fun initBinding() {
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_addition)
+        binding.vm = viewModel
+        binding.lifecycleOwner = this
+    }
+
+
+    private fun btnDeleteActionOnClickListener() {
+        with(binding) {
+            btnAdditionDeleteAction1.setOnClickListener {
+                if (viewModel.additionActionName2.value != blank) {
+                    viewModel.additionActionName1.value = viewModel.additionActionName2.value
+                    viewModel.additionActionName2.value = blank
+                    tvAdditionAction2.visibility = View.GONE
+                    btnAdditionDeleteAction2.visibility = View.GONE
+                } else {
+                    viewModel.additionActionName1.value = blank
+                    tvAdditionAction1.visibility = View.GONE
+                    btnAdditionDeleteAction1.visibility = View.GONE
+                }
+            }
+            btnAdditionDeleteAction2.setOnClickListener {
+                viewModel.additionActionName2.value = blank
+                tvAdditionAction2.visibility = View.GONE
+                btnAdditionDeleteAction2.visibility = View.GONE
+            }
+        }
+    }
+
+    private fun btnActionPlusOnClickListener() {
+        binding.btnAdditionActionPlus.setOnClickListener {
+            if (viewModel.additionActionName.value != blank) {
+                if (viewModel.additionActionName1.value == blank) {
+                    viewModel.additionActionName1.value =
+                        viewModel.additionActionName.value
+                    binding.tvAdditionAction1.visibility = View.VISIBLE
+                    binding.btnAdditionDeleteAction1.visibility = View.VISIBLE
+                    viewModel.additionActionName.value = blank
+                } else if (viewModel.additionActionName2.value == blank) {
+                    viewModel.additionActionName2.value =
+                        viewModel.additionActionName.value
+                    binding.tvAdditionAction2.visibility = View.VISIBLE
+                    binding.btnAdditionDeleteAction2.visibility = View.VISIBLE
+                    viewModel.additionActionName.value = blank
+                } else {
+                    Toast.makeText(
+                        this@AdditionActivity,
+                        additionToastText, Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+
+        }
+    }
+
+    companion object {
+        const val additionRecentHeader = "낫투두 기록"
+        val additionRecentSearch: List<String> = listOf(
+            "침대에 다시 눕지 않기", "알람 끄고 다시 자지 않기",
+            "10시 이후에 일어나지 않기", "일어났으면 다시 침대에 눕지 않기", "모바일 게임 하지 않기"
+        )
+        const val blank = ""
+        const val additionToastText = "낫투두 액션은 2개 이상 불가능~"
+    }
+}

--- a/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/view/AdditionActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/view/AdditionActivity.kt
@@ -49,22 +49,22 @@ class AdditionActivity : AppCompatActivity() {
 
     private fun btnDeleteActionOnClickListener() {
         with(binding) {
-            btnAdditionDeleteAction1.setOnClickListener {
-                if (viewModel.additionActionName2.value != blank) {
-                    viewModel.additionActionName1.value = viewModel.additionActionName2.value
-                    viewModel.additionActionName2.value = blank
-                    tvAdditionAction2.visibility = View.GONE
-                    btnAdditionDeleteAction2.visibility = View.GONE
+            btnAdditionDeleteActionFirst.setOnClickListener {
+                if (viewModel.additionActionNameSecond.value != blank) {
+                    viewModel.additionActionNameFirst.value = viewModel.additionActionNameSecond.value
+                    viewModel.additionActionNameSecond.value = blank
+                    tvAdditionActionSecond.visibility = View.GONE
+                    btnAdditionDeleteActionSecond.visibility = View.GONE
                 } else {
-                    viewModel.additionActionName1.value = blank
-                    tvAdditionAction1.visibility = View.GONE
-                    btnAdditionDeleteAction1.visibility = View.GONE
+                    viewModel.additionActionNameFirst.value = blank
+                    tvAdditionActionFirst.visibility = View.GONE
+                    btnAdditionDeleteActionFirst.visibility = View.GONE
                 }
             }
-            btnAdditionDeleteAction2.setOnClickListener {
-                viewModel.additionActionName2.value = blank
-                tvAdditionAction2.visibility = View.GONE
-                btnAdditionDeleteAction2.visibility = View.GONE
+            btnAdditionDeleteActionSecond.setOnClickListener {
+                viewModel.additionActionNameSecond.value = blank
+                tvAdditionActionSecond.visibility = View.GONE
+                btnAdditionDeleteActionSecond.visibility = View.GONE
             }
         }
     }
@@ -72,17 +72,17 @@ class AdditionActivity : AppCompatActivity() {
     private fun btnActionPlusOnClickListener() {
         binding.btnAdditionActionPlus.setOnClickListener {
             if (viewModel.additionActionName.value != blank) {
-                if (viewModel.additionActionName1.value == blank) {
-                    viewModel.additionActionName1.value =
+                if (viewModel.additionActionNameFirst.value == blank) {
+                    viewModel.additionActionNameFirst.value =
                         viewModel.additionActionName.value
-                    binding.tvAdditionAction1.visibility = View.VISIBLE
-                    binding.btnAdditionDeleteAction1.visibility = View.VISIBLE
+                    binding.tvAdditionActionFirst.visibility = View.VISIBLE
+                    binding.btnAdditionDeleteActionFirst.visibility = View.VISIBLE
                     viewModel.additionActionName.value = blank
-                } else if (viewModel.additionActionName2.value == blank) {
-                    viewModel.additionActionName2.value =
+                } else if (viewModel.additionActionNameSecond.value == blank) {
+                    viewModel.additionActionNameSecond.value =
                         viewModel.additionActionName.value
-                    binding.tvAdditionAction2.visibility = View.VISIBLE
-                    binding.btnAdditionDeleteAction2.visibility = View.VISIBLE
+                    binding.tvAdditionActionSecond.visibility = View.VISIBLE
+                    binding.btnAdditionDeleteActionSecond.visibility = View.VISIBLE
                     viewModel.additionActionName.value = blank
                 } else {
                     Toast.makeText(

--- a/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/view/AdditionActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/view/AdditionActivity.kt
@@ -8,6 +8,7 @@ import androidx.databinding.DataBindingUtil
 import kr.co.nottodo.R
 import kr.co.nottodo.databinding.ActivityAdditionBinding
 import kr.co.nottodo.presentation.schedule.addition.viewmodel.AdditionViewModel
+import kr.co.nottodo.presentation.schedule.bottomsheet.view.CalendarBottomSheet
 
 class AdditionActivity : AppCompatActivity() {
     lateinit var binding: ActivityAdditionBinding
@@ -19,6 +20,7 @@ class AdditionActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_addition)
         initBinding()
+        initBottomSheet()
         binding.btnAdditionAdd.setOnClickListener {
             // 서버 통신을 통해 낫투두 추가하는 기능
         }
@@ -37,6 +39,12 @@ class AdditionActivity : AppCompatActivity() {
         binding = DataBindingUtil.setContentView(this, R.layout.activity_addition)
         binding.vm = viewModel
         binding.lifecycleOwner = this
+    }
+
+    private fun initBottomSheet() {
+        binding.layoutAdditionCalendar.setOnClickListener {
+            CalendarBottomSheet().show(supportFragmentManager, CalendarBottomSheet().tag)
+        }
     }
 
 

--- a/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/viewmodel/AdditionViewModel.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/viewmodel/AdditionViewModel.kt
@@ -12,14 +12,14 @@ class AdditionViewModel : ViewModel() {
         it.isNotEmpty()
     }
 
-    val additionActionName1: MutableLiveData<String> = MutableLiveData("")
-    val isAdditionActionName1Filled: LiveData<Boolean> = Transformations.map(additionActionName1) {
+    val additionActionNameFirst: MutableLiveData<String> = MutableLiveData("")
+    private val isAdditionActionName1Filled: LiveData<Boolean> = Transformations.map(additionActionNameFirst) {
         it.isNotEmpty()
     }
-    val additionActionName2: MutableLiveData<String> = MutableLiveData("")
+    val additionActionNameSecond: MutableLiveData<String> = MutableLiveData("")
 
     val additionSituationName: MutableLiveData<String> = MutableLiveData("입력하기")
-    val isAdditionSituationNameSuit: LiveData<Boolean> =
+    private val isAdditionSituationNameSuit: LiveData<Boolean> =
         Transformations.map(additionSituationName) {
             it != "입력하기"
         }

--- a/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/viewmodel/AdditionViewModel.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/viewmodel/AdditionViewModel.kt
@@ -1,0 +1,55 @@
+package kr.co.nottodo.presentation.schedule.addition.viewmodel
+
+import androidx.lifecycle.*
+
+class AdditionViewModel : ViewModel() {
+    val additionMissionName: MutableLiveData<String> = MutableLiveData("")
+    val isAdditionMissionNameFilled: LiveData<Boolean> = Transformations.map(additionMissionName) {
+        it.isNotEmpty()
+    }
+    val additionActionName: MutableLiveData<String> = MutableLiveData("")
+    val isAdditionActionNameFilled: LiveData<Boolean> = Transformations.map(additionActionName) {
+        it.isNotEmpty()
+    }
+
+    val additionActionName1: MutableLiveData<String> = MutableLiveData("")
+    val isAdditionActionName1Filled: LiveData<Boolean> = Transformations.map(additionActionName1) {
+        it.isNotEmpty()
+    }
+    val additionActionName2: MutableLiveData<String> = MutableLiveData("")
+
+    val additionSituationName: MutableLiveData<String> = MutableLiveData("입력하기")
+    val isAdditionSituationNameSuit: LiveData<Boolean> =
+        Transformations.map(additionSituationName) {
+            it != "입력하기"
+        }
+
+    val additionGoalName: MutableLiveData<String> = MutableLiveData("")
+    val isAdditionGoalNameFilled: LiveData<Boolean> = Transformations.map(additionGoalName) {
+        it.isNotEmpty()
+    }
+
+    val isBtnSuitConditions: MediatorLiveData<Boolean> = MediatorLiveData()
+
+    init {
+        isBtnSuitConditions.addSource(isAdditionMissionNameFilled) {
+            isBtnSuitConditions.value = _isBtnSuitConditions()
+        }
+        isBtnSuitConditions.addSource(isAdditionActionName1Filled) {
+            isBtnSuitConditions.value = _isBtnSuitConditions()
+        }
+        isBtnSuitConditions.addSource(isAdditionSituationNameSuit) {
+            isBtnSuitConditions.value = _isBtnSuitConditions()
+        }
+        isBtnSuitConditions.addSource(isAdditionGoalNameFilled) {
+            isBtnSuitConditions.value = _isBtnSuitConditions()
+        }
+    }
+
+    private fun _isBtnSuitConditions(): Boolean {
+        return (isAdditionMissionNameFilled.value == true
+                && isAdditionActionName1Filled.value == true
+                && isAdditionSituationNameSuit.value == true
+                && isAdditionGoalNameFilled.value == true)
+    }
+}

--- a/app/src/main/res/drawable/rectangle_border_gray2_1.xml
+++ b/app/src/main/res/drawable/rectangle_border_gray2_1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke android:color="@color/gray_2_8e8e93"
+        android:width="1dp"/>
+</shape>

--- a/app/src/main/res/drawable/rectangle_border_gray4_0point5.xml
+++ b/app/src/main/res/drawable/rectangle_border_gray4_0point5.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke android:color="@color/gray_4_d7d7d8"
+        android:width="0.5dp"/>
+</shape>

--- a/app/src/main/res/drawable/rectangle_border_gray4_1.xml
+++ b/app/src/main/res/drawable/rectangle_border_gray4_1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke android:color="@color/gray_4_d7d7d8"
+        android:width="1dp"/>
+</shape>

--- a/app/src/main/res/drawable/rectangle_border_gray_0point5_radius_5.xml
+++ b/app/src/main/res/drawable/rectangle_border_gray_0point5_radius_5.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/bg_f5f5f5" />
+    <stroke
+        android:width="0.5dp"
+        android:color="@color/gray_5_cfcfcf" />
+    <corners android:radius="5dp" />
+</shape>

--- a/app/src/main/res/layout/activity_addition.xml
+++ b/app/src/main/res/layout/activity_addition.xml
@@ -212,7 +212,7 @@
                         app:layout_constraintTop_toTopOf="@id/et_addition_action_name" />
 
                     <TextView
-                        android:id="@+id/tv_addition_action_1"
+                        android:id="@+id/tv_addition_action_first"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="0dp"
@@ -226,20 +226,20 @@
                         android:visibility="gone"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/et_addition_action_name"
-                        android:text="@={vm.additionActionName1}" />
+                        android:text="@={vm.additionActionNameFirst}" />
 
                     <ImageView
-                        android:id="@+id/btn_addition_delete_action_1"
+                        android:id="@+id/btn_addition_delete_action_first"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:src="@drawable/ic_btn_delete_create"
                         android:visibility="gone"
-                        app:layout_constraintBottom_toBottomOf="@id/tv_addition_action_1"
-                        app:layout_constraintStart_toEndOf="@id/tv_addition_action_1"
-                        app:layout_constraintTop_toTopOf="@id/tv_addition_action_1" />
+                        app:layout_constraintBottom_toBottomOf="@id/tv_addition_action_first"
+                        app:layout_constraintStart_toEndOf="@id/tv_addition_action_first"
+                        app:layout_constraintTop_toTopOf="@id/tv_addition_action_first" />
 
                     <TextView
-                        android:id="@+id/tv_addition_action_2"
+                        android:id="@+id/tv_addition_action_second"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="8dp"
@@ -251,18 +251,18 @@
                         android:theme="@style/M14"
                         android:visibility="gone"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/tv_addition_action_1"
-                        android:text="@={vm.additionActionName2}" />
+                        app:layout_constraintTop_toBottomOf="@id/tv_addition_action_first"
+                        android:text="@={vm.additionActionNameSecond}" />
 
                     <ImageView
-                        android:id="@+id/btn_addition_delete_action_2"
+                        android:id="@+id/btn_addition_delete_action_second"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:src="@drawable/ic_btn_delete_create"
                         android:visibility="gone"
-                        app:layout_constraintBottom_toBottomOf="@id/tv_addition_action_2"
-                        app:layout_constraintStart_toEndOf="@id/tv_addition_action_2"
-                        app:layout_constraintTop_toTopOf="@id/tv_addition_action_2" />
+                        app:layout_constraintBottom_toBottomOf="@id/tv_addition_action_second"
+                        app:layout_constraintStart_toEndOf="@id/tv_addition_action_second"
+                        app:layout_constraintTop_toTopOf="@id/tv_addition_action_second" />
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/activity_addition.xml
+++ b/app/src/main/res/layout/activity_addition.xml
@@ -1,0 +1,433 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="kr.co.nottodo.presentation.schedule.addition.viewmodel.AdditionViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ScrollView
+            android:id="@+id/scroll_view_addition"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/btn_addition_add"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="1.0">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:context=".presentation.schedule.addition.view.AdditionActivity">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_addition_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="15dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <TextView
+                        android:id="@+id/tv_addition_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="낫투두 추가하기"
+                        android:textColor="@color/gray_1_626068"
+                        android:textStyle="bold"
+                        android:theme="@style/Sb22"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <ImageView
+                        android:id="@+id/iv_addition_delete_page"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="20dp"
+                        android:src="@drawable/ic_btn_delete_page"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_addition_mission"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="40dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_addition_title">
+
+                    <TextView
+                        android:id="@+id/tv_addition_mission_name"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="하지 않을 일을 적어주세요"
+                        android:theme="@style/M16"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <!--                    <com.google.android.material.textfield.TextInputLayout-->
+                    <!--                        android:id="@+id/layout_addition_mission_name"-->
+                    <!--                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"-->
+                    <!--                        android:layout_width="0dp"-->
+                    <!--                        android:layout_height="wrap_content"-->
+                    <!--                        android:layout_marginTop="15dp"-->
+                    <!--                        android:maxLength="20"-->
+                    <!--                        android:textColor="@color/gray_1_626068"-->
+                    <!--                        android:textColorHint="@color/gray_3_c4c4c4"-->
+                    <!--                        android:theme="@style/M16"-->
+                    <!--                        app:layout_constraintEnd_toEndOf="parent"-->
+                    <!--                        app:layout_constraintStart_toStartOf="parent"-->
+                    <!--                        app:layout_constraintTop_toBottomOf="@id/tv_addition_mission_name">-->
+
+                    <!--                        <AutoCompleteTextView-->
+                    <!--                            android:id="@+id/et_addition_mission_name"-->
+                    <!--                            android:layout_width="match_parent"-->
+                    <!--                            android:layout_height="match_parent"-->
+                    <!--                            android:background="@drawable/rectangle_border_gray4_1"-->
+                    <!--                            android:hint="ex) 유튜브 2시간 이상 보지 않기"-->
+                    <!--                            android:maxLength="20"-->
+                    <!--                            android:text="@={vm.additionMissionName}" />-->
+                    <!--                    </com.google.android.material.textfield.TextInputLayout>-->
+                    <EditText
+                        android:id="@+id/et_addition_mission_name"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="15dp"
+                        android:background="@drawable/rectangle_border_gray4_1"
+                        android:hint="ex) 유튜브 2시간 이상 보지 않기"
+                        android:maxLength="20"
+                        android:padding="15dp"
+                        android:text="@={vm.additionMissionName}"
+                        android:textColor="@color/gray_1_626068"
+                        android:textColorHint="@color/gray_3_c4c4c4"
+                        android:theme="@style/M16"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_addition_mission_name" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_addition_action"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="30dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_addition_mission">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/layout_addition_action_recommend"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <TextView
+                            android:id="@+id/tv_addition_action_name"
+                            style="@style/M16"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="구체적인 실천 행동은 무엇인가요?"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:id="@+id/layout_addition_move_recommend_page"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent">
+
+                            <TextView
+                                android:id="@+id/tv_addition_move_recommend_page"
+                                style="@style/M16"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="추천 받기"
+                                android:textColor="@color/gray_2_8e8e93"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toStartOf="@id/iv_addition_move_recommend_page"
+                                app:layout_constraintTop_toTopOf="parent" />
+
+                            <ImageView
+                                android:id="@+id/iv_addition_move_recommend_page"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:src="@drawable/ic_arrow"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintTop_toTopOf="parent" />
+                        </androidx.constraintlayout.widget.ConstraintLayout>
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    <EditText
+                        android:id="@+id/et_addition_action_name"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="11dp"
+                        android:layout_marginEnd="8dp"
+                        android:background="@drawable/rectangle_border_gray4_1"
+                        android:hint="ex) 9시 이후 휴대폰 가방에 기기"
+                        android:maxLength="18"
+                        android:padding="15dp"
+                        android:text="@={vm.additionActionName}"
+                        android:textColor="@color/gray_1_626068"
+                        android:textColorHint="@color/gray_3_c4c4c4"
+                        android:theme="@style/M16"
+                        app:layout_constraintEnd_toStartOf="@id/btn_addition_action_plus"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/layout_addition_action_recommend" />
+
+                    <ImageView
+                        android:id="@+id/btn_addition_action_plus"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:layout_marginEnd="19dp"
+                        android:src="@drawable/ic_btn_plus"
+                        app:layout_constraintBottom_toBottomOf="@id/et_addition_action_name"
+                        app:layout_constraintDimensionRatio="1"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/et_addition_action_name" />
+
+                    <TextView
+                        android:id="@+id/tv_addition_action_1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="0dp"
+                        android:layout_marginTop="7dp"
+                        android:background="@drawable/rectangle_border_gray4_0point5"
+                        android:paddingHorizontal="15dp"
+                        android:paddingTop="12dp"
+                        android:paddingBottom="11dp"
+                        android:textColor="@color/gray_2_8e8e93"
+                        android:theme="@style/M14"
+                        android:visibility="gone"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/et_addition_action_name"
+                        android:text="@={vm.additionActionName1}" />
+
+                    <ImageView
+                        android:id="@+id/btn_addition_delete_action_1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_btn_delete_create"
+                        android:visibility="gone"
+                        app:layout_constraintBottom_toBottomOf="@id/tv_addition_action_1"
+                        app:layout_constraintStart_toEndOf="@id/tv_addition_action_1"
+                        app:layout_constraintTop_toTopOf="@id/tv_addition_action_1" />
+
+                    <TextView
+                        android:id="@+id/tv_addition_action_2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:background="@drawable/rectangle_border_gray4_0point5"
+                        android:paddingHorizontal="15dp"
+                        android:paddingTop="12dp"
+                        android:paddingBottom="11dp"
+                        android:textColor="@color/gray_2_8e8e93"
+                        android:theme="@style/M14"
+                        android:visibility="gone"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_addition_action_1"
+                        android:text="@={vm.additionActionName2}" />
+
+                    <ImageView
+                        android:id="@+id/btn_addition_delete_action_2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_btn_delete_create"
+                        android:visibility="gone"
+                        app:layout_constraintBottom_toBottomOf="@id/tv_addition_action_2"
+                        app:layout_constraintStart_toEndOf="@id/tv_addition_action_2"
+                        app:layout_constraintTop_toTopOf="@id/tv_addition_action_2" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_addition_situation"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="32dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_addition_action">
+
+                    <TextView
+                        android:id="@+id/tv_addition_situation_title"
+                        style="@style/M16"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="어떤 상황인가요?"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/layout_addition_move_situation_page"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <TextView
+                            android:id="@+id/tv_addition_situation_name"
+                            style="@style/M16"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@={vm.additionSituationName}"
+                            android:textColor="@color/gray_2_8e8e93"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/iv_addition_move_situation_page"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <ImageView
+                            android:id="@+id/iv_addition_move_situation_page"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:src="@drawable/ic_arrow"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_addition_goal"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="33dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_addition_situation">
+
+                    <TextView
+                        android:id="@+id/tv_addition_goal_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="이루고자 하는 목표는 무엇인가요?"
+                        android:theme="@style/M16"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <EditText
+                        android:id="@+id/et_addition_goal_title"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="13dp"
+                        android:background="@drawable/rectangle_border_gray4_1"
+                        android:hint="ex) 유튜브 2시간 이상 보지 않기"
+                        android:maxLength="18"
+                        android:padding="15dp"
+                        android:text="@={vm.additionGoalName}"
+                        android:textColor="@color/gray_1_626068"
+                        android:textColorHint="@color/gray_3_c4c4c4"
+                        android:theme="@style/M16"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_addition_goal_title" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_addition_date"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="30dp"
+                    android:paddingBottom="30dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_addition_goal">
+
+                    <TextView
+                        android:id="@+id/tv_addition_date_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="실천 날짜"
+                        android:theme="@style/M16"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/layout_addition_calendar"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/rectangle_border_gray_0point5_radius_5"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <TextView
+                            android:id="@+id/tv_addition_date"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginVertical="9dp"
+                            android:layout_marginStart="20dp"
+                            android:layout_marginEnd="10dp"
+                            android:text="2022.12.16"
+                            android:textColor="@color/gray_1_626068"
+                            android:theme="@style/M16"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/iv_addition_calendar"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <ImageView
+                            android:id="@+id/iv_addition_calendar"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginEnd="13dp"
+                            android:src="@drawable/ic_calender"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toEndOf="@id/tv_addition_date"
+                            app:layout_constraintTop_toTopOf="parent" />
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_addition_add"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@color/gray_2_8e8e93"
+            android:paddingVertical="18dp"
+            android:text="추가하기"
+            android:textColor="@color/white"
+            android:theme="@style/B18"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:enabled="false"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,15 @@
     android:background="@color/bg_f5f5f5"
     tools:context=".presentation.MainActivity">
 
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container_view_main"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/custom_bottom"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/custom_bottom"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,6 +12,7 @@
     <color name="gray_2_8e8e93">#8e8e93</color>
     <color name="gray_3_c4c4c4">#c4c4c4</color>
     <color name="gray_4_d7d7d8">#d7d7d8</color>
+    <color name="gray_5_cfcfcf">#cfcfcf</color>
     <color name="bg_f5f5f5">#f5f5f5</color>
     <color name="yellow_mild_fbf8af">#fbf8af</color>
     <color name="yellow_basic_fef652">#fef652</color>


### PR DESCRIPTION
## 👻 작업한 내용

- 전반적 뷰 스케치
- 드롭다운 메뉴 연결
- 에디트 텍스트 옆 버튼 누르면 새로운 뷰 동적 생성, 밑의 뷰 체인 다시 걸기
- 바텀 시트 연결하기
- 조건에 맞을 시 버튼 활성화

### 해결 못한 이슈
1. 아직 행동 추천 뷰 안 나와서 연결 X
2. 아직 상황 추가 뷰 안 나와서 연결 X
3. 드롭다운 메뉴 연결 X
4. 에디트텍스트 바깥 터치 시 포커스 제거

## 🎤 PR Point

- 뷰모델을 잘 활용했는가 ?

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

### 입력 X
<img width="328" alt="스크린샷 2023-01-03 오후 5 01 27" src="https://user-images.githubusercontent.com/108331578/210318916-c34c9a55-ad1c-4a42-9c4e-a9e440c96b24.png">

### 입력 O
<img width="328" alt="스크린샷 2023-01-03 오후 5 02 06" src="https://user-images.githubusercontent.com/108331578/210318984-bedd078f-e73b-45ac-a5c9-27096b384118.png">

### 실천 행동 1 제거 시 2번째것이 위로 올라감
<img width="325" alt="스크린샷 2023-01-03 오후 5 04 08" src="https://user-images.githubusercontent.com/108331578/210319222-a4552d2b-f42e-4c3f-a3ad-1f4a6d0ae9a4.png">

### 바텀 시트 연결
<img width="328" alt="스크린샷 2023-01-03 오후 5 03 33" src="https://user-images.githubusercontent.com/108331578/210319137-a431b659-929a-4a4c-99c7-7f4bba415fa1.png">


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #13 