### PR TITLE
[UI]#32 하단 여백 수정(92dp->46dp)

### DIFF
--- a/app/src/main/res/layout/fragment_achievement.xml
+++ b/app/src/main/res/layout/fragment_achievement.xml
@@ -78,7 +78,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
             android:layout_marginTop="15dp"
-            android:layout_marginBottom="97dp"
+            android:layout_marginBottom="46dp"
             android:text="* 8월 1달간의 낫투두를 바탕으로 만들어진 자료에요!"
             android:textColor="@color/gray_2_8e8e93"
             android:theme="@style/M12"


### PR DESCRIPTION
## 👻 작업한 내용

### 성취 뷰에서 마진값만 바꾸면 되는 간단한 이슈

## 🎤 PR Point


## 📸 스크린샷

### 기존 여백

<img width="408" alt="스크린샷 2023-01-06 오후 10 48 53" src="https://user-images.githubusercontent.com/108331578/211025060-c17eb5cf-27f8-446a-947e-bda2a710d0ad.png">

### 수정된 여백

<img width="310" alt="스크린샷 2023-01-06 오후 10 49 15" src="https://user-images.githubusercontent.com/108331578/211025111-903e9160-7f92-449b-9900-6a52a94f0c08.png">


## 📮 관련 이슈

- Resolved: #32 
