### PR TITLE
[fix]#30 변수 추가하여 상황명이 "입력하기" 여도 추가하기 버튼 활성화되도록 수정

### DIFF
--- a/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/view/AdditionActivity.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/view/AdditionActivity.kt
@@ -2,6 +2,7 @@ package kr.co.nottodo.presentation.schedule.addition.view
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
@@ -32,18 +33,18 @@ class AdditionActivity : AppCompatActivity() {
         binding.tvAdditionMissionName.setOnClickListener {
             moveToSearchActivity()
         }
-        moveToSearchActivity()
         binding.btnAdditionAdd.setOnClickListener {
-            // 서버 통신을 통해 낫투두 추가하는 기능
+            // TODO by 김준서 : 서버 통신을 통해 낫투두 추가하는 기능
         }
         binding.layoutAdditionMoveSituationPage.setOnClickListener {
-            // 상황 추가 화면으로 이동
+            // TODO by 김준서 : 상황 추가 화면으로 이동 - 상황 추가 화면 구현시 개발
         }
         binding.ivAdditionMoveSituationPage.setOnClickListener {
-            viewModel.additionSituationName.value = "출근 시간"
-        } // 추후 상황 추가 화면 구현시 개발
+            viewModel.additionSituationName.value = "입력하기"
+            viewModel.isAdditionSituationNameFilled.value = true
+        } // TODO by 김준서 : 추후 상황 추가 화면 구현시 개발
         binding.layoutAdditionMoveRecommendPage.setOnClickListener {
-            // 추후 행동 추천 화면 구현시 개발
+            // TODO by 김준서 : 추후 행동 추천 화면 구현시 개발
         }
         observeEditText()
         btnDeleteActionOnClickListener()

--- a/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/viewmodel/AdditionViewModel.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/schedule/addition/viewmodel/AdditionViewModel.kt
@@ -28,6 +28,7 @@ class AdditionViewModel : ViewModel() {
         Transformations.map(additionSituationName) {
             it != "입력하기"
         }
+    val isAdditionSituationNameFilled: MutableLiveData<Boolean> = MutableLiveData(false)
 
     val additionGoalName: MutableLiveData<String> = MutableLiveData("")
     val isAdditionGoalNameFilled: LiveData<Boolean> = Transformations.map(additionGoalName) {
@@ -43,7 +44,7 @@ class AdditionViewModel : ViewModel() {
         isBtnSuitConditions.addSource(isAdditionActionNameFirstFilled) {
             isBtnSuitConditions.value = _isBtnSuitConditions()
         }
-        isBtnSuitConditions.addSource(isAdditionSituationNameSuit) {
+        isBtnSuitConditions.addSource(isAdditionSituationNameFilled) {
             isBtnSuitConditions.value = _isBtnSuitConditions()
         }
         isBtnSuitConditions.addSource(isAdditionGoalNameFilled) {
@@ -54,7 +55,7 @@ class AdditionViewModel : ViewModel() {
     private fun _isBtnSuitConditions(): Boolean {
         return (isAdditionMissionNameFilled.value == true
                 && isAdditionActionNameFirstFilled.value == true
-                && isAdditionSituationNameSuit.value == true
+                && isAdditionSituationNameFilled.value == true
                 && isAdditionGoalNameFilled.value == true)
     }
 }


### PR DESCRIPTION
## 👻 작업한 내용

- 만약 사용자가 상황에 "입력하기"를 입력할 경우, 추가하기 버튼이 비활성화

## 🎤 PR Point

## 📸 스크린샷

### "입력하기" 입력 전
<img width="360" alt="스크린샷 2023-01-06 오후 10 40 19" src="https://user-images.githubusercontent.com/108331578/211023687-6e921488-dc79-4eca-9e50-8bceb4d05499.png">

### "입력하기" 입력 후
<img width="352" alt="스크린샷 2023-01-06 오후 10 40 54" src="https://user-images.githubusercontent.com/108331578/211023801-4e5498d6-ae24-42d7-b5bd-f2345993d7ff.png">


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #30 