### PR TITLE
[FIX]#34 성취뷰 뷰페이저 크기에 관한 버그

### DIFF
--- a/app/src/main/java/kr/co/nottodo/presentation/achievement/view/AchievementFragment.kt
+++ b/app/src/main/java/kr/co/nottodo/presentation/achievement/view/AchievementFragment.kt
@@ -39,8 +39,12 @@ class AchievementFragment : Fragment() {
         binding.viewpagerAchievement.adapter = adapter
         binding.viewpagerAchievement.registerOnPageChangeCallback(object :
             ViewPager2.OnPageChangeCallback() {
-            override fun onPageSelected(position: Int) {
-                super.onPageSelected(position)
+            override fun onPageScrolled(
+                position: Int,
+                positionOffset: Float,
+                positionOffsetPixels: Int
+            ) {
+                super.onPageScrolled(position, positionOffset, positionOffsetPixels)
                 adapter.notifyDataSetChanged()
             }
         })


### PR DESCRIPTION
## 👻 작업한 내용

1. 상황별 통계 보기로 넘어갈 때 뷰 페이저 작아지지 않는 현상
2. 탭 레이아웃 클릭 시 뷰 페이저 크기가 변하지 않는 현상

> notifyDataSetChanged()를 
onPageSelected가 아닌, onPageScrolled에서 사용하니 해결 !

## 🎤 PR Point

## 📸 스크린샷

## 📮 관련 이슈

- Resolved: #34 
